### PR TITLE
Add newline to ref generation

### DIFF
--- a/src/test/test_pulsarDb.cxx
+++ b/src/test/test_pulsarDb.cxx
@@ -3587,7 +3587,7 @@ void PulsarDbTestApp::testMssModelEph() {
   t_eph.append("SHAPIRO_R",    "44.4e-06",                   "s");
   t_eph.append("SHAPIRO_S",    "55.5",                       "");
   t_eph.append("ABERRATION_A", "66.6",                       "s");
-  t_eph.append("ABERRATION_B", "77.7",                       "s");
+  t_eph.append("ABERRATION_B", "77.7",                       "s\n");
   checkEphParameter(getMethod() + "_numeric", *eph, t_eph);
 
   // Test the constructor that takes a FITS record.


### PR DESCRIPTION
Fixes parsing problem in test comparison